### PR TITLE
observability: update example

### DIFF
--- a/observability/example/Makefile.env
+++ b/observability/example/Makefile.env
@@ -1,6 +1,8 @@
 
 # Main Options
 
+#- Example mode: server or client (server,client) [server]
+MODE                 ?= server
 #- Generate and print config definition in given format and exit (default: '', means skip) (,json,md,mk) []
 CONFIG_GEN           ?=
 #- Dump config dest filename (string) []
@@ -25,6 +27,13 @@ HTTP_ETAG            ?= false
 HTTP_TLS_CERT        ?=
 #- KeyFile for serving HTTPS instead HTTP (string) []
 HTTP_TLS_KEY         ?=
+
+# Client Options
+
+#- HTTP server URL (string) [http://localhost:8080/demo]
+CLIENT_URL           ?= http://localhost:8080/demo
+#- HTTP request timeout (time.Duration) [3s]
+CLIENT_TIMEOUT       ?= 3s
 
 # OpenTelemetry Options
 

--- a/observability/example/README.md
+++ b/observability/example/README.md
@@ -1,45 +1,23 @@
 # observability example
 
-Пример показывает базовый контракт:
+Минимальный пример HTTP-сервиса с observability:
 
-* приложение на Go отправляет traces и metrics в OTLP endpoint;
-* приложение пишет logs в stdout/stderr;
-* `observability.Service` настраивает OpenTelemetry providers и HTTP middleware;
-* OpenTelemetry Collector принимает telemetry, добавляет infra attributes, батчит и отправляет данные в выбранное хранилище.
-* Collector можно расширить profiling данными, чтобы собирать базовые серверные metrics: CPU, RAM, network, load и process count через `hostmetrics` receiver.
-
-В этом примере backendом выбран OpenObserve потому, что он легковесный и умеет работать сразу и с логами, и с метриками, и с трейсами. Код приложения не зависит от OpenObserve.
+* `observability.Service` настраивает traces и metrics;
+* HTTP middleware собирает server spans и HTTP metrics;
+* handler добавляет custom span, custom metric и исходящий HTTP-вызов.
 
 ## Запуск
 
-Из каталога `observability/example`:
-
 ```sh
 make up
-```
-
-Запустить приложение:
-
-```sh
 go run . --otel.enable_traces --otel.enable_metrics
 ```
 
-`OTEL_EXPORTER_OTLP_ENDPOINT` задается только URL-форматом, например `http://127.0.0.1:4317` для Collector на том же сервере или `https://collector.example.com:4317` для TLS endpoint. Формат `host:port` не поддерживается.
-
-Traces и metrics выключены по умолчанию, чтобы простой локальный запуск не пытался отправлять telemetry в Collector. Включить их можно независимо:
+Сделайте несколько запросов, чтобы появились метрики.
 
 ```sh
-go run . --otel.enable_traces
-go run . --otel.enable_metrics
+curl -v http://localhost:8080/demo
 ```
-
-Проверить HTTP handler:
-
-```sh
-curl -v http://localhost:8080/hello
-```
-
-Сделайте несколько запросов, чтобы появились spans и HTTP metrics.
 
 OpenObserve UI:
 
@@ -47,15 +25,10 @@ OpenObserve UI:
 http://localhost:5080
 ```
 
-Логин:
+Логин и пароль лежат в `.env`:
 
 ```sh
 grep ZO_ROOT_USER_EMAIL .env
-```
-
-Пароль:
-
-```sh
 grep ZO_ROOT_USER_PASSWORD .env
 ```
 
@@ -63,12 +36,6 @@ grep ZO_ROOT_USER_PASSWORD .env
 
 ```sh
 docker compose logs -f otel-collector
-```
-
-App metrics по умолчанию отключены вместе с общим metrics-сигналом. Включить их можно флагом:
-
-```sh
-go run . --otel.enable_metrics
 ```
 
 Базовый набор metrics, который должен появиться после запросов:
@@ -96,27 +63,7 @@ go run . --otel.enable_metrics --otel.enable_go_runtime_metrics
 | `go.processor.limit`    | Лимит процессоров, доступных Go runtime.                |
 | `go.schedule.duration`  | Время задержки планирования goroutine.                  |
 
-Если добавить `hostmetrics` receiver в `otel-collector.yaml` и подключить его к `metrics` pipeline, Collector начнет собирать системные метрики хоста:
-
-```yaml
-receivers:
-  hostmetrics:
-    collection_interval: 10s
-    root_path: /hostfs
-    scrapers:
-      cpu:
-      memory:
-      network:
-      load:
-      processes:
-
-service:
-  pipelines:
-    metrics:
-      receivers: [otlp, hostmetrics]
-```
-
-В OpenObserve после этого добавятся метрики:
+В `otel-collector.yaml` добавлен receiver `hostmetrics`, который собирает системные метрики хоста:
 
 | Metric                        | Описание                                                      |
 |-------------------------------|---------------------------------------------------------------|
@@ -133,34 +80,65 @@ service:
 | `system.processes.count`      | Количество процессов по состояниям.                           |
 | `system.processes.created`    | Количество созданных процессов.                               |
 
-
-## Другие backend-ы
-
-Go-приложение не нужно менять при переходе с OpenObserve на другое хранилище. Меняется только конфиг OpenTelemetry Collector.
-
-Collector уже собирает CPU, RAM, network, load и process count с сервера через `hostmetrics`. Его можно расширить disk/filesystem/paging metrics или profiling pipeline, если backend умеет принимать profiles. Эти сигналы не требуют изменений в коде приложения: сервис по-прежнему отправляет свои traces/metrics в OTLP и пишет logs в stdout/stderr, а серверная telemetry собирается на уровне инфраструктуры.
-
-Примеры направлений:
-
-* Loki: отправлять logs из Collector/Filelog/Journald receiver в `loki` exporter, а traces/metrics оставить в других pipeline.
-* Prometheus: включить `prometheus` exporter в metrics pipeline, чтобы Prometheus scrape-ил Collector endpoint.
-* VictoriaMetrics: отправлять metrics через `prometheusremotewrite` exporter в VictoriaMetrics.
-* Tempo: отправлять traces через `otlp` exporter в Tempo.
-* Jaeger: отправлять traces через OTLP или Jaeger exporter, в зависимости от версии стека.
-* Datadog/New Relic/Honeycomb: заменить exporter в Collector на vendor-specific exporter или OTLP endpoint вендора.
-
-Граница ответственности остается такой:
+Trace для `GET /demo` содержит:
 
 ```text
-Go app
-  traces/metrics -> OTLP Collector endpoint
-  logs           -> stdout/stderr
+HTTP server span for /demo
+├── demo.calculate
+└── HTTP GET
+```
 
-OpenTelemetry Collector
-  receivers   -> otlp/filelog/journald/...
-  processors  -> resource/batch/filter/sampling/...
-  exporters   -> OpenObserve/Loki/Prometheus/VictoriaMetrics/Tempo/Datadog/...
-  hostmetrics -> CPU/RAM/network/load/process metrics, optional disk/profiles
+## Главное в коде
+
+`observability.New` создает providers, а middleware подключает HTTP instrumentation:
+
+```go
+obs, err := observability.New(ctx, cfg.Observability, application, version)
+srv.Use(obs.HTTPMiddleware())
+```
+
+Custom metric создается один раз в конструкторе handler-а:
+
+```go
+requests, err := meter.Int64Counter(
+    "demo.custom.requests",
+    metric.WithDescription("Number of custom demo handler calls."),
+    metric.WithUnit("{request}"),
+)
+```
+
+Custom span создается вокруг своего участка кода:
+
+```go
+_, span := h.tracer.Start(ctx, "demo.calculate")
+defer span.End()
+
+span.SetAttributes(attribute.String("demo.step", "calculate"))
+```
+
+Custom metric:
+
+```go
+h.requests.Add(ctx, 1, metric.WithAttributes(
+    attribute.String("demo.operation", "request"),
+))
+```
+
+Внешний HTTP API в примере имитируется через `httptest.NewServer`. В реальном сервисе здесь будет URL вашей зависимости.
+
+`obs.InstallGlobal()` делает providers доступными для стандартной instrumentation. Поэтому `otelhttp.NewTransport` создает span для исходящего HTTP-запроса, а `r.Context()` связывает его с текущим server span:
+
+```go
+restore := obs.InstallGlobal()
+defer restore()
+
+client := &http.Client{
+    Transport: otelhttp.NewTransport(http.DefaultTransport),
+    Timeout:   3 * time.Second,
+}
+
+req, err := http.NewRequestWithContext(ctx, http.MethodGet, h.externalURL, nil)
+resp, err := h.client.Do(req)
 ```
 
 ## Остановка

--- a/observability/example/README.md
+++ b/observability/example/README.md
@@ -1,22 +1,28 @@
 # observability example
 
-Минимальный пример HTTP-сервиса с observability:
+Минимальный пример HTTP server и HTTP client с observability:
 
-* `observability.Service` настраивает traces и metrics;
-* HTTP middleware собирает server spans и HTTP metrics;
-* handler добавляет custom span, custom metric и исходящий HTTP-вызов.
+* `server` mode показывает HTTP middleware для server spans и HTTP metrics;
+* `handler` добавляет custom span и custom metric;
+* `client` передает W3C trace context через `otelhttp.NewTransport`, а server продолжает trace через HTTP middleware.
 
 ## Запуск
 
 ```sh
 make up
-go run . --otel.enable_traces --otel.enable_metrics
+go run . --mode server --otel.enable_traces --otel.enable_metrics
 ```
 
-Сделайте несколько запросов, чтобы появились метрики.
+Обычный запрос:
 
 ```sh
 curl -v http://localhost:8080/demo
+```
+
+Запрос с trace context:
+
+```sh
+go run . --mode client --otel.enable_traces
 ```
 
 OpenObserve UI:
@@ -38,13 +44,57 @@ grep ZO_ROOT_USER_PASSWORD .env
 docker compose logs -f otel-collector
 ```
 
-Базовый набор metrics, который должен появиться после запросов:
+## Traces
+
+Обычный `curl` создает trace на server:
+
+```text
+curl -> server:
+observability-example-server /demo
+└── observability-example-server demo.calculate
+```
+
+`client` mode создает trace на client и продолжает его на server:
+
+```text
+demo client -> server:
+observability-example-client demo.client.request
+└── localhost HTTP GET
+    └── observability-example-server /demo
+        └── observability-example-server demo.calculate
+```
+
+`localhost HTTP GET` добавляет `traceparent`, а server middleware читает его и связывает `/demo` с client trace.
+
+В `client` mode `obs.InstallGlobal()` делает providers доступными для `otelhttp.NewTransport`.
+
+## Metrics
+
+Базовый набор server metrics, который должен появиться после запросов:
 
 | Metric                           | Описание                    |
 |----------------------------------|-----------------------------|
 | `http.server.request.duration`   | Длительность HTTP-запросов. |
 | `http.server.request.body.size`  | Размер тела HTTP-запроса.   |
 | `http.server.response.body.size` | Размер тела HTTP-ответа.    |
+
+Custom metric создается один раз в конструкторе handler-а:
+
+```go
+requests, err := meter.Int64Counter(
+    "demo.custom.requests",
+    metric.WithDescription("Number of custom demo handler calls."),
+    metric.WithUnit("{request}"),
+)
+```
+
+Custom metric записывается внутри handler-а:
+
+```go
+h.requests.Add(ctx, 1, metric.WithAttributes(
+    attribute.String("demo.operation", "request"),
+))
+```
 
 Метрики Go runtime включаются отдельным флагом:
 
@@ -80,14 +130,6 @@ go run . --otel.enable_metrics --otel.enable_go_runtime_metrics
 | `system.processes.count`      | Количество процессов по состояниям.                           |
 | `system.processes.created`    | Количество созданных процессов.                               |
 
-Trace для `GET /demo` содержит:
-
-```text
-HTTP server span for /demo
-├── demo.calculate
-└── HTTP GET
-```
-
 ## Главное в коде
 
 `observability.New` создает providers, а middleware подключает HTTP instrumentation:
@@ -95,50 +137,6 @@ HTTP server span for /demo
 ```go
 obs, err := observability.New(ctx, cfg.Observability, application, version)
 srv.Use(obs.HTTPMiddleware())
-```
-
-Custom metric создается один раз в конструкторе handler-а:
-
-```go
-requests, err := meter.Int64Counter(
-    "demo.custom.requests",
-    metric.WithDescription("Number of custom demo handler calls."),
-    metric.WithUnit("{request}"),
-)
-```
-
-Custom span создается вокруг своего участка кода:
-
-```go
-_, span := h.tracer.Start(ctx, "demo.calculate")
-defer span.End()
-
-span.SetAttributes(attribute.String("demo.step", "calculate"))
-```
-
-Custom metric:
-
-```go
-h.requests.Add(ctx, 1, metric.WithAttributes(
-    attribute.String("demo.operation", "request"),
-))
-```
-
-Внешний HTTP API в примере имитируется через `httptest.NewServer`. В реальном сервисе здесь будет URL вашей зависимости.
-
-`obs.InstallGlobal()` делает providers доступными для стандартной instrumentation. Поэтому `otelhttp.NewTransport` создает span для исходящего HTTP-запроса, а `r.Context()` связывает его с текущим server span:
-
-```go
-restore := obs.InstallGlobal()
-defer restore()
-
-client := &http.Client{
-    Transport: otelhttp.NewTransport(http.DefaultTransport),
-    Timeout:   3 * time.Second,
-}
-
-req, err := http.NewRequestWithContext(ctx, http.MethodGet, h.externalURL, nil)
-resp, err := h.client.Do(req)
 ```
 
 ## Остановка

--- a/observability/example/client.go
+++ b/observability/example/client.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/LeKovr/go-kit/observability"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+)
+
+type ClientConfig struct {
+	URL     string        `default:"http://localhost:8080/demo" description:"HTTP server URL"      env:"URL"     long:"url"`
+	Timeout time.Duration `default:"3s"                         description:"HTTP request timeout" env:"TIMEOUT" long:"timeout"`
+}
+
+func runClient(ctx context.Context, cfg ClientConfig, obs *observability.Service) error {
+	// otelhttp.NewTransport uses process-wide providers and propagators by default.
+	restore := obs.InstallGlobal()
+	defer restore()
+
+	ctx, span := obs.Tracer(application+"/client").Start(ctx, "demo.client.request")
+	defer span.End()
+
+	client := &http.Client{
+		Transport: otelhttp.NewTransport(http.DefaultTransport),
+		Timeout:   cfg.Timeout,
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, cfg.URL, nil)
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return fmt.Errorf("unexpected status: %s: %s", resp.Status, string(body))
+	}
+
+	_, err = os.Stdout.Write(body)
+
+	return err
+}

--- a/observability/example/go.mod
+++ b/observability/example/go.mod
@@ -6,6 +6,9 @@ require (
 	github.com/LeKovr/go-kit/config v0.0.0
 	github.com/LeKovr/go-kit/observability v0.0.0
 	github.com/LeKovr/go-kit/server v0.0.0
+	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.69.0
+	go.opentelemetry.io/otel/metric v1.44.0
+	go.opentelemetry.io/otel/trace v1.44.0
 )
 
 require (
@@ -21,16 +24,13 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
 	github.com/jessevdk/go-flags v1.6.1 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
-	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.69.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/runtime v0.69.0 // indirect
 	go.opentelemetry.io/otel v1.44.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.44.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.44.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.44.0 // indirect
-	go.opentelemetry.io/otel/metric v1.44.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.44.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.44.0 // indirect
-	go.opentelemetry.io/otel/trace v1.44.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	golang.org/x/net v0.56.0 // indirect
 	golang.org/x/sync v0.21.0 // indirect

--- a/observability/example/main.go
+++ b/observability/example/main.go
@@ -3,25 +3,20 @@ package main
 import (
 	"context"
 	"fmt"
-	"io"
 	"log/slog"
-	"net/http"
-	"net/http/httptest"
 	"os"
-	"time"
 
 	"github.com/LeKovr/go-kit/config"
 	"github.com/LeKovr/go-kit/observability"
 	"github.com/LeKovr/go-kit/server"
-	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/metric"
-	"go.opentelemetry.io/otel/trace"
 )
 
 // Config holds all config vars.
 type Config struct {
+	Mode string `long:"mode" default:"server" choice:"server" choice:"client" description:"Example mode: server or client" env:"MODE"`
+
 	Server        server.Config        `group:"HTTP Options" namespace:"http" env-namespace:"HTTP"`
+	Client        ClientConfig         `group:"Client Options" namespace:"client" env-namespace:"CLIENT"`
 	Observability observability.Config `group:"OpenTelemetry Options" namespace:"otel" env-namespace:"OTEL"`
 
 	config.EnableShowVersion
@@ -48,9 +43,10 @@ func main() {
 	}
 
 	ctx := context.Background()
+	serviceName := application + "-" + cfg.Mode
 
 	var obs *observability.Service
-	if obs, err = observability.New(ctx, cfg.Observability, application, version); err != nil {
+	if obs, err = observability.New(ctx, cfg.Observability, serviceName, version); err != nil {
 		return
 	}
 
@@ -60,117 +56,12 @@ func main() {
 		}
 	}()
 
-	// observability.New keeps providers local; the app opts in to globals so
-	// standard instrumentation, such as otelhttp.NewTransport, can use them.
-	restore := obs.InstallGlobal()
-	defer restore()
-
-	external := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		time.Sleep(150 * time.Millisecond)
-		_, _ = w.Write([]byte("external ok\n"))
-	}))
-	defer external.Close()
-
-	const instrumentation = application + "/custom"
-
-	demoHandler, err := NewDemoHandler(
-		obs.Tracer(instrumentation),
-		obs.Meter(instrumentation),
-		external.URL,
-	)
-	if err != nil {
-		return
+	switch cfg.Mode {
+	case "server":
+		err = runServer(ctx, cfg, obs)
+	case "client":
+		err = runClient(ctx, cfg.Client, obs)
+	default:
+		err = fmt.Errorf("unsupported mode %q", cfg.Mode)
 	}
-
-	srv := server.New(cfg.Server)
-	srv.Use(obs.HTTPMiddleware())
-	srv.ServeMux().HandleFunc("/demo", demoHandler.Handle)
-
-	if err = srv.Run(ctx); err != nil {
-		return
-	}
-}
-
-type DemoHandler struct {
-	tracer      trace.Tracer
-	client      *http.Client
-	externalURL string
-
-	requests metric.Int64Counter
-}
-
-func NewDemoHandler(tracer trace.Tracer, meter metric.Meter, externalURL string) (*DemoHandler, error) {
-	requests, err := meter.Int64Counter(
-		"demo.custom.requests",
-		metric.WithDescription("Number of custom demo handler calls."),
-		metric.WithUnit("{request}"),
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	return &DemoHandler{
-		tracer: tracer,
-		client: &http.Client{
-			// NewTransport uses the providers installed by obs.InstallGlobal().
-			Transport: otelhttp.NewTransport(http.DefaultTransport),
-			Timeout:   3 * time.Second,
-		},
-		externalURL: externalURL,
-		requests:    requests,
-	}, nil
-}
-
-func (h DemoHandler) Handle(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodGet {
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
-
-		return
-	}
-
-	h.RecordRequest(r.Context())
-	h.Calculate(r.Context())
-
-	if er := h.CallExternal(r.Context()); er != nil {
-		http.Error(w, er.Error(), http.StatusInternalServerError)
-
-		return
-	}
-
-	_, _ = w.Write([]byte("ok\n"))
-}
-
-func (h DemoHandler) RecordRequest(ctx context.Context) {
-	h.requests.Add(ctx, 1, metric.WithAttributes(
-		attribute.String("demo.operation", "request"),
-	))
-}
-
-func (h DemoHandler) Calculate(ctx context.Context) {
-	_, span := h.tracer.Start(ctx, "demo.calculate")
-	defer span.End()
-
-	span.SetAttributes(attribute.String("demo.step", "calculate"))
-	time.Sleep(250 * time.Millisecond)
-}
-
-func (h DemoHandler) CallExternal(ctx context.Context) error {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, h.externalURL, nil)
-	if err != nil {
-		return err
-	}
-
-	resp, err := h.client.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	_, _ = io.Copy(io.Discard, resp.Body)
-
-	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
-		return fmt.Errorf("external request failed: %s", resp.Status)
-	}
-
-	return nil
 }

--- a/observability/example/main.go
+++ b/observability/example/main.go
@@ -2,14 +2,21 @@ package main
 
 import (
 	"context"
-	"log"
+	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
+	"net/http/httptest"
 	"os"
+	"time"
 
 	"github.com/LeKovr/go-kit/config"
 	"github.com/LeKovr/go-kit/observability"
 	"github.com/LeKovr/go-kit/server"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // Config holds all config vars.
@@ -53,15 +60,117 @@ func main() {
 		}
 	}()
 
+	// observability.New keeps providers local; the app opts in to globals so
+	// standard instrumentation, such as otelhttp.NewTransport, can use them.
+	restore := obs.InstallGlobal()
+	defer restore()
+
+	external := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(150 * time.Millisecond)
+		_, _ = w.Write([]byte("external ok\n"))
+	}))
+	defer external.Close()
+
+	const instrumentation = application + "/custom"
+
+	demoHandler, err := NewDemoHandler(
+		obs.Tracer(instrumentation),
+		obs.Meter(instrumentation),
+		external.URL,
+	)
+	if err != nil {
+		return
+	}
+
 	srv := server.New(cfg.Server)
 	srv.Use(obs.HTTPMiddleware())
-	srv.ServeMux().HandleFunc("/hello", func(w http.ResponseWriter, r *http.Request) {
-		slog.InfoContext(r.Context(), "hello request")
-		_, _ = w.Write([]byte("hello\n"))
-	})
+	srv.ServeMux().HandleFunc("/demo", demoHandler.Handle)
 
-	err = srv.Run(ctx)
-	if err != nil {
-		log.Print(err)
+	if err = srv.Run(ctx); err != nil {
+		return
 	}
+}
+
+type DemoHandler struct {
+	tracer      trace.Tracer
+	client      *http.Client
+	externalURL string
+
+	requests metric.Int64Counter
+}
+
+func NewDemoHandler(tracer trace.Tracer, meter metric.Meter, externalURL string) (*DemoHandler, error) {
+	requests, err := meter.Int64Counter(
+		"demo.custom.requests",
+		metric.WithDescription("Number of custom demo handler calls."),
+		metric.WithUnit("{request}"),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &DemoHandler{
+		tracer: tracer,
+		client: &http.Client{
+			// NewTransport uses the providers installed by obs.InstallGlobal().
+			Transport: otelhttp.NewTransport(http.DefaultTransport),
+			Timeout:   3 * time.Second,
+		},
+		externalURL: externalURL,
+		requests:    requests,
+	}, nil
+}
+
+func (h DemoHandler) Handle(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+
+		return
+	}
+
+	h.RecordRequest(r.Context())
+	h.Calculate(r.Context())
+
+	if er := h.CallExternal(r.Context()); er != nil {
+		http.Error(w, er.Error(), http.StatusInternalServerError)
+
+		return
+	}
+
+	_, _ = w.Write([]byte("ok\n"))
+}
+
+func (h DemoHandler) RecordRequest(ctx context.Context) {
+	h.requests.Add(ctx, 1, metric.WithAttributes(
+		attribute.String("demo.operation", "request"),
+	))
+}
+
+func (h DemoHandler) Calculate(ctx context.Context) {
+	_, span := h.tracer.Start(ctx, "demo.calculate")
+	defer span.End()
+
+	span.SetAttributes(attribute.String("demo.step", "calculate"))
+	time.Sleep(250 * time.Millisecond)
+}
+
+func (h DemoHandler) CallExternal(ctx context.Context) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, h.externalURL, nil)
+	if err != nil {
+		return err
+	}
+
+	resp, err := h.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	_, _ = io.Copy(io.Discard, resp.Body)
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return fmt.Errorf("external request failed: %s", resp.Status)
+	}
+
+	return nil
 }

--- a/observability/example/server.go
+++ b/observability/example/server.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/LeKovr/go-kit/observability"
+	"github.com/LeKovr/go-kit/server"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/trace"
+)
+
+type DemoHandler struct {
+	tracer trace.Tracer
+
+	requests metric.Int64Counter
+}
+
+func runServer(ctx context.Context, cfg Config, obs *observability.Service) error {
+	const instrumentation = application + "/server"
+
+	demoHandler, err := NewDemoHandler(
+		obs.Tracer(instrumentation),
+		obs.Meter(instrumentation),
+	)
+	if err != nil {
+		return err
+	}
+
+	srv := server.New(cfg.Server)
+	srv.Use(obs.HTTPMiddleware())
+	srv.ServeMux().HandleFunc("/demo", demoHandler.Handle)
+
+	return srv.Run(ctx)
+}
+
+func NewDemoHandler(tracer trace.Tracer, meter metric.Meter) (*DemoHandler, error) {
+	requests, err := meter.Int64Counter(
+		"demo.custom.requests",
+		metric.WithDescription("Number of custom demo handler calls."),
+		metric.WithUnit("{request}"),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &DemoHandler{
+		tracer:   tracer,
+		requests: requests,
+	}, nil
+}
+
+func (h DemoHandler) Handle(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+
+		return
+	}
+
+	h.RecordRequest(r.Context())
+	h.Calculate(r.Context())
+
+	_, _ = w.Write([]byte("ok\n"))
+}
+
+func (h DemoHandler) RecordRequest(ctx context.Context) {
+	h.requests.Add(ctx, 1, metric.WithAttributes(
+		attribute.String("demo.operation", "request"),
+	))
+}
+
+func (h DemoHandler) Calculate(ctx context.Context) {
+	_, span := h.tracer.Start(ctx, "demo.calculate")
+	defer span.End()
+
+	span.SetAttributes(attribute.String("demo.step", "calculate"))
+	time.Sleep(250 * time.Millisecond)
+}

--- a/observability/http.go
+++ b/observability/http.go
@@ -51,6 +51,7 @@ func (svc Service) HTTPMiddleware(opts ...HTTPOption) func(http.Handler) http.Ha
 		}),
 		otelhttp.WithTracerProvider(svc.tracerProviderOrNoop()),
 		otelhttp.WithMeterProvider(svc.meterProviderOrNoop()),
+		otelhttp.WithPropagators(svc.propagator()),
 	}
 
 	otelMiddleware := otelhttp.NewMiddleware(svc.serviceName, otelOpts...)

--- a/observability/http.go
+++ b/observability/http.go
@@ -36,28 +36,24 @@ func WithSpanNameFormatter(formatter func(string, *http.Request) string) HTTPOpt
 }
 
 // HTTPMiddleware returns a net/http middleware compatible with server.Handler.
-func (srv Service) HTTPMiddleware(opts ...HTTPOption) func(http.Handler) http.Handler {
+func (svc Service) HTTPMiddleware(opts ...HTTPOption) func(http.Handler) http.Handler {
 	cfg := defaultHTTPConfig()
 	for _, opt := range opts {
 		opt(&cfg)
 	}
 
 	otelOpts := []otelhttp.Option{
-		otelhttp.WithServerName(srv.serviceName),
+		otelhttp.WithServerName(svc.serviceName),
 		otelhttp.WithSpanNameFormatter(cfg.spanNameFormatter),
 		otelhttp.WithFilter(func(r *http.Request) bool {
 			_, ignored := cfg.ignoredPaths[r.URL.Path]
 			return !ignored
 		}),
-	}
-	if srv.tracerProvider != nil {
-		otelOpts = append(otelOpts, otelhttp.WithTracerProvider(srv.tracerProvider))
-	}
-	if srv.meterProvider != nil {
-		otelOpts = append(otelOpts, otelhttp.WithMeterProvider(srv.meterProvider))
+		otelhttp.WithTracerProvider(svc.tracerProviderOrNoop()),
+		otelhttp.WithMeterProvider(svc.meterProviderOrNoop()),
 	}
 
-	otelMiddleware := otelhttp.NewMiddleware(srv.serviceName, otelOpts...)
+	otelMiddleware := otelhttp.NewMiddleware(svc.serviceName, otelOpts...)
 
 	return func(next http.Handler) http.Handler {
 		return otelMiddleware(next)

--- a/observability/observability.go
+++ b/observability/observability.go
@@ -140,10 +140,7 @@ func (svc *Service) InstallGlobal() func() {
 
 	otel.SetTracerProvider(svc.tracerProviderOrNoop())
 	otel.SetMeterProvider(svc.meterProviderOrNoop())
-	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
-		propagation.TraceContext{},
-		propagation.Baggage{},
-	))
+	otel.SetTextMapPropagator(svc.propagator())
 
 	return func() {
 		otel.SetTracerProvider(previousTracerProvider)
@@ -203,6 +200,13 @@ func (svc Service) tracerProviderOrNoop() trace.TracerProvider {
 	}
 
 	return nooptrace.NewTracerProvider()
+}
+
+func (svc Service) propagator() propagation.TextMapPropagator {
+	return propagation.NewCompositeTextMapPropagator(
+		propagation.TraceContext{},
+		propagation.Baggage{},
+	)
 }
 
 func newResource(cfg Config, serviceName, serviceVersion string) (*resource.Resource, error) {

--- a/observability/observability.go
+++ b/observability/observability.go
@@ -51,7 +51,7 @@ type Service struct {
 
 // New creates OpenTelemetry providers for traces and metrics.
 func New(ctx context.Context, cfg Config, serviceName, serviceVersion string) (*Service, error) {
-	srv := &Service{
+	svc := &Service{
 		serviceName:    serviceName,
 		serviceVersion: serviceVersion,
 		config:         cfg,
@@ -60,7 +60,7 @@ func New(ctx context.Context, cfg Config, serviceName, serviceVersion string) (*
 	}
 
 	if !cfg.EnableTraces && !cfg.EnableMetrics {
-		return srv, nil
+		return svc, nil
 	}
 
 	r, err := newResource(cfg, serviceName, serviceVersion)
@@ -74,27 +74,27 @@ func New(ctx context.Context, cfg Config, serviceName, serviceVersion string) (*
 			return nil, err
 		}
 
-		srv.meterProvider = meterProvider
-		srv.shutdowns = append(srv.shutdowns, meterProvider.Shutdown)
+		svc.meterProvider = meterProvider
+		svc.shutdowns = append(svc.shutdowns, meterProvider.Shutdown)
 	}
 
 	if cfg.EnableTraces {
 		tracerProvider, err := newTracerProvider(ctx, cfg, r)
 		if err != nil {
-			return nil, errors.Join(err, srv.Shutdown(ctx))
+			return nil, errors.Join(err, svc.Shutdown(ctx))
 		}
 
-		srv.tracerProvider = tracerProvider
-		srv.shutdowns = append(srv.shutdowns, tracerProvider.Shutdown)
+		svc.tracerProvider = tracerProvider
+		svc.shutdowns = append(svc.shutdowns, tracerProvider.Shutdown)
 	}
 
 	if cfg.EnableMetrics && cfg.EnableGoRuntimeMetrics {
-		if err := otelruntime.Start(otelruntime.WithMeterProvider(srv.meterProvider)); err != nil {
-			return nil, errors.Join(err, srv.Shutdown(ctx))
+		if err := otelruntime.Start(otelruntime.WithMeterProvider(svc.meterProvider)); err != nil {
+			return nil, errors.Join(err, svc.Shutdown(ctx))
 		}
 	}
 
-	return srv, nil
+	return svc, nil
 }
 
 func newMeterProvider(ctx context.Context, cfg Config, r *resource.Resource) (*sdkmetric.MeterProvider, error) {
@@ -133,18 +133,13 @@ func newTracerProvider(ctx context.Context, cfg Config, r *resource.Resource) (*
 // InstallGlobal configures this service as the process-wide OpenTelemetry
 // provider set. It returns a restore function useful for tests and embedded
 // applications.
-func (srv *Service) InstallGlobal() func() {
+func (svc *Service) InstallGlobal() func() {
 	previousTracerProvider := otel.GetTracerProvider()
 	previousMeterProvider := otel.GetMeterProvider()
 	previousPropagator := otel.GetTextMapPropagator()
 
-	if srv.tracerProvider != nil {
-		otel.SetTracerProvider(srv.tracerProvider)
-	}
-	if srv.meterProvider != nil {
-		otel.SetMeterProvider(srv.meterProvider)
-	}
-
+	otel.SetTracerProvider(svc.tracerProviderOrNoop())
+	otel.SetMeterProvider(svc.meterProviderOrNoop())
 	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
 		propagation.TraceContext{},
 		propagation.Baggage{},
@@ -158,14 +153,14 @@ func (srv *Service) InstallGlobal() func() {
 }
 
 // Shutdown flushes and stops OpenTelemetry providers.
-func (srv Service) Shutdown(ctx context.Context) error {
-	if srv.config.ShutdownTimeout > 0 {
+func (svc Service) Shutdown(ctx context.Context) error {
+	if svc.config.ShutdownTimeout > 0 {
 		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(ctx, srv.config.ShutdownTimeout)
+		ctx, cancel = context.WithTimeout(ctx, svc.config.ShutdownTimeout)
 		defer cancel()
 	}
 
-	return shutdownAll(ctx, srv.shutdowns...)
+	return shutdownAll(ctx, svc.shutdowns...)
 }
 
 func shutdownAll(ctx context.Context, funcs ...func(context.Context) error) error {
@@ -185,21 +180,29 @@ func shutdownAll(ctx context.Context, funcs ...func(context.Context) error) erro
 }
 
 // Meter returns a meter for application-specific instruments.
-func (srv Service) Meter(name string, opts ...otelmetric.MeterOption) otelmetric.Meter {
-	if srv.meterProvider != nil {
-		return srv.meterProvider.Meter(name, opts...)
-	}
-
-	return noopmetric.NewMeterProvider().Meter(name, opts...)
+func (svc Service) Meter(name string, opts ...otelmetric.MeterOption) otelmetric.Meter {
+	return svc.meterProviderOrNoop().Meter(name, opts...)
 }
 
 // Tracer returns a tracer for application-specific spans.
-func (srv Service) Tracer(name string, opts ...trace.TracerOption) trace.Tracer {
-	if srv.tracerProvider != nil {
-		return srv.tracerProvider.Tracer(name, opts...)
+func (svc Service) Tracer(name string, opts ...trace.TracerOption) trace.Tracer {
+	return svc.tracerProviderOrNoop().Tracer(name, opts...)
+}
+
+func (svc Service) meterProviderOrNoop() otelmetric.MeterProvider {
+	if svc.meterProvider != nil {
+		return svc.meterProvider
 	}
 
-	return nooptrace.NewTracerProvider().Tracer(name, opts...)
+	return noopmetric.NewMeterProvider()
+}
+
+func (svc Service) tracerProviderOrNoop() trace.TracerProvider {
+	if svc.tracerProvider != nil {
+		return svc.tracerProvider
+	}
+
+	return nooptrace.NewTracerProvider()
 }
 
 func newResource(cfg Config, serviceName, serviceVersion string) (*resource.Resource, error) {

--- a/observability/observability_test.go
+++ b/observability/observability_test.go
@@ -9,16 +9,18 @@ import (
 
 	"go.opentelemetry.io/otel"
 	otelmetric "go.opentelemetry.io/otel/metric"
+	noopmetric "go.opentelemetry.io/otel/metric/noop"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	oteltrace "go.opentelemetry.io/otel/trace"
+	nooptrace "go.opentelemetry.io/otel/trace/noop"
 )
 
 func TestServiceShutdownWithoutProviders(t *testing.T) {
-	var srv Service
-	if err := srv.Shutdown(context.Background()); err != nil {
+	var svc Service
+	if err := svc.Shutdown(context.Background()); err != nil {
 		t.Fatalf("shutdown: %v", err)
 	}
 }
@@ -28,7 +30,7 @@ func TestServiceShutdownRunsAllHooksAndJoinsErrors(t *testing.T) {
 	secondErr := errors.New("second shutdown")
 	var calls []string
 
-	srv := Service{
+	svc := Service{
 		shutdowns: []func(context.Context) error{
 			func(context.Context) error {
 				calls = append(calls, "first")
@@ -42,7 +44,7 @@ func TestServiceShutdownRunsAllHooksAndJoinsErrors(t *testing.T) {
 		},
 	}
 
-	err := srv.Shutdown(context.Background())
+	err := svc.Shutdown(context.Background())
 	if !errors.Is(err, firstErr) {
 		t.Fatalf("shutdown error does not include first error: %v", err)
 	}
@@ -65,11 +67,11 @@ func TestServiceInstallGlobalRestoresPreviousProviders(t *testing.T) {
 		_ = meterProvider.Shutdown(context.Background())
 	}()
 
-	srv := Service{
+	svc := Service{
 		tracerProvider: tracerProvider,
 		meterProvider:  meterProvider,
 	}
-	restore := srv.InstallGlobal()
+	restore := svc.InstallGlobal()
 
 	if otel.GetTracerProvider() != tracerProvider {
 		t.Fatal("global tracer provider was not installed")
@@ -106,7 +108,7 @@ func TestValidateOTLPEndpointURL(t *testing.T) {
 }
 
 func TestNewWithTracesAndMetricsDisabledSkipsExporterSetup(t *testing.T) {
-	srv, err := New(context.Background(), Config{
+	svc, err := New(context.Background(), Config{
 		OTLPEndpoint:   "not-a-url",
 		EnableTraces:   false,
 		EnableMetrics:  false,
@@ -116,10 +118,10 @@ func TestNewWithTracesAndMetricsDisabledSkipsExporterSetup(t *testing.T) {
 		t.Fatalf("new service: %v", err)
 	}
 
-	if srv.tracerProvider == nil {
+	if svc.tracerProvider == nil {
 		t.Fatal("tracer provider should be set to noop")
 	}
-	if srv.meterProvider == nil {
+	if svc.meterProvider == nil {
 		t.Fatal("meter provider should be set to noop")
 	}
 }
@@ -135,8 +137,12 @@ func TestServiceHTTPMiddlewareCreatesSpan(t *testing.T) {
 	}()
 
 	var gotSpan bool
-	srv := Service{serviceName: "test-service"}
-	handler := srv.HTTPMiddleware()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	svc := Service{
+		serviceName:    "test-service",
+		tracerProvider: provider,
+		meterProvider:  noopmetric.NewMeterProvider(),
+	}
+	handler := svc.HTTPMiddleware()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotSpan = oteltrace.SpanContextFromContext(r.Context()).IsValid()
 		w.WriteHeader(http.StatusAccepted)
 	}))
@@ -171,8 +177,12 @@ func TestServiceHTTPMiddlewareUsesConfiguredServiceName(t *testing.T) {
 		_ = provider.Shutdown(context.Background())
 	}()
 
-	srv := Service{serviceName: "test-service"}
-	handler := srv.HTTPMiddleware()(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	svc := Service{
+		serviceName:    "test-service",
+		tracerProvider: provider,
+		meterProvider:  noopmetric.NewMeterProvider(),
+	}
+	handler := svc.HTTPMiddleware()(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusAccepted)
 	}))
 
@@ -198,11 +208,12 @@ func TestHTTPMiddlewareRecordsBaseMetrics(t *testing.T) {
 		_ = provider.Shutdown(context.Background())
 	}()
 
-	srv := Service{
-		serviceName:   "test-service",
-		meterProvider: provider,
+	svc := Service{
+		serviceName:    "test-service",
+		tracerProvider: nooptrace.NewTracerProvider(),
+		meterProvider:  provider,
 	}
-	handler := srv.HTTPMiddleware()(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	handler := svc.HTTPMiddleware()(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = w.Write([]byte("ok"))
 	}))
 
@@ -235,14 +246,14 @@ func TestHTTPMiddlewareWithTracesDisabledDoesNotUseGlobalProvider(t *testing.T) 
 		_ = provider.Shutdown(context.Background())
 	}()
 
-	srv, err := New(context.Background(), Config{
+	svc, err := New(context.Background(), Config{
 		EnableTraces:  false,
 		EnableMetrics: false,
 	}, "test-service", "test-version")
 	if err != nil {
 		t.Fatalf("new service: %v", err)
 	}
-	handler := srv.HTTPMiddleware()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	handler := svc.HTTPMiddleware()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if oteltrace.SpanContextFromContext(r.Context()).IsValid() {
 			t.Fatal("disabled traces should not create a span")
 		}
@@ -271,14 +282,14 @@ func TestHTTPMiddlewareWithMetricsDisabledDoesNotUseGlobalProvider(t *testing.T)
 		_ = provider.Shutdown(context.Background())
 	}()
 
-	srv, err := New(context.Background(), Config{
+	svc, err := New(context.Background(), Config{
 		EnableTraces:  false,
 		EnableMetrics: false,
 	}, "test-service", "test-version")
 	if err != nil {
 		t.Fatalf("new service: %v", err)
 	}
-	handler := srv.HTTPMiddleware()(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	handler := svc.HTTPMiddleware()(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = w.Write([]byte("ok"))
 	}))
 
@@ -303,8 +314,8 @@ func TestServiceMeterRecordsBusinessMetric(t *testing.T) {
 		_ = provider.Shutdown(context.Background())
 	}()
 
-	srv := Service{meterProvider: provider}
-	meter := srv.Meter("test/business")
+	svc := Service{meterProvider: provider}
+	meter := svc.Meter("test/business")
 	processed, err := meter.Int64Counter("business.processed", otelmetric.WithDescription("Processed business events."))
 	if err != nil {
 		t.Fatalf("create counter: %v", err)
@@ -332,8 +343,8 @@ func TestServiceMeterWithoutProviderDoesNotUseGlobalProvider(t *testing.T) {
 		_ = provider.Shutdown(context.Background())
 	}()
 
-	var srv Service
-	meter := srv.Meter("test/business")
+	var svc Service
+	meter := svc.Meter("test/business")
 	processed, err := meter.Int64Counter("business.processed")
 	if err != nil {
 		t.Fatalf("create counter: %v", err)
@@ -361,8 +372,12 @@ func TestHTTPMiddlewareIgnoresDefaultPaths(t *testing.T) {
 		_ = provider.Shutdown(context.Background())
 	}()
 
-	srv := Service{serviceName: "test-service"}
-	handler := srv.HTTPMiddleware()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	svc := Service{
+		serviceName:    "test-service",
+		tracerProvider: provider,
+		meterProvider:  noopmetric.NewMeterProvider(),
+	}
+	handler := svc.HTTPMiddleware()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if oteltrace.SpanContextFromContext(r.Context()).IsValid() {
 			t.Fatal("ignored request should not have a valid span")
 		}

--- a/observability/observability_test.go
+++ b/observability/observability_test.go
@@ -10,6 +10,7 @@ import (
 	"go.opentelemetry.io/otel"
 	otelmetric "go.opentelemetry.io/otel/metric"
 	noopmetric "go.opentelemetry.io/otel/metric/noop"
+	"go.opentelemetry.io/otel/propagation"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"go.opentelemetry.io/otel/sdk/trace"
@@ -269,6 +270,51 @@ func TestHTTPMiddlewareWithTracesDisabledDoesNotUseGlobalProvider(t *testing.T) 
 	}
 	if spans := exporter.GetSpans(); len(spans) != 0 {
 		t.Fatalf("expected no spans, got %d", len(spans))
+	}
+}
+
+func TestHTTPMiddlewareUsesServicePropagator(t *testing.T) {
+	exporter := tracetest.NewInMemoryExporter()
+	provider := trace.NewTracerProvider(trace.WithSyncer(exporter))
+	previousPropagator := otel.GetTextMapPropagator()
+	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator())
+	defer func() {
+		otel.SetTextMapPropagator(previousPropagator)
+		_ = provider.Shutdown(context.Background())
+	}()
+
+	svc := Service{
+		serviceName:    "test-service",
+		tracerProvider: provider,
+		meterProvider:  noopmetric.NewMeterProvider(),
+	}
+	handler := svc.HTTPMiddleware()(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusAccepted)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/propagated", nil)
+	req.Header.Set("traceparent", "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("unexpected status: %d", rec.Code)
+	}
+
+	spans := exporter.GetSpans()
+	if len(spans) != 1 {
+		t.Fatalf("expected one span, got %d", len(spans))
+	}
+
+	parent := spans[0].Parent
+	if !parent.IsValid() {
+		t.Fatal("expected propagated parent span context")
+	}
+	if got, want := parent.TraceID().String(), "4bf92f3577b34da6a3ce929d0e0e4736"; got != want {
+		t.Fatalf("unexpected parent trace id: %s, want %s", got, want)
+	}
+	if got, want := parent.SpanID().String(), "00f067aa0ba902b7"; got != want {
+		t.Fatalf("unexpected parent span id: %s, want %s", got, want)
 	}
 }
 


### PR DESCRIPTION
Adds an observability example for custom metrics, custom traces, and instrumented outgoing HTTP calls, with explicit global provider installation for standard OTel instrumentation.